### PR TITLE
Changes to make capture resolution adjustable

### DIFF
--- a/raspicam_cv/Makefile
+++ b/raspicam_cv/Makefile
@@ -3,7 +3,7 @@ OBJS = objs
 CFLAGS_OPENCV = -I/usr/include/opencv
 LDFLAGS2_OPENCV = -lopencv_highgui -lopencv_core -lopencv_legacy -lopencv_video -lopencv_features2d -lopencv_calib3d -lopencv_imgproc
 
-USERLAND_ROOT = $(HOME)/git/raspberrypi/userland
+USERLAND_ROOT = $(HOME)/dev/userland
 CFLAGS_PI = \
 	-I$(USERLAND_ROOT)/host_applications/linux/libs/bcm_host/include \
 	-I$(USERLAND_ROOT)/host_applications/linux/apps/raspicam \

--- a/raspicam_cv/README
+++ b/raspicam_cv/README
@@ -42,11 +42,9 @@ cvCreateCameraCapture and delivers pictures in 640x480 resolution)
 -cvQueryFrame -> raspiCamCvQueryFrame
 -CvCapture -> RaspiCamCvCapture
 
-If you want to capture pictures in a different resolution that 640x480, you can
-also instantiate your own RaspiCamCvCapture by calling
-raspiCamCvCreateCameraCaptureWithDims. This is the function that
-cvCreateCameraCapture delegates to. It allows you to set the dimensions of the
-pictures in pixels directly.
+If you want to set the capture's resolution manually, use
+raspiCamCvSetCaptureProperty. Otherwise the querying the frame will return an
+image in the camera's native resolution (2592x1944 px).
 
 Credits:
 --------------------------------------------------

--- a/raspicam_cv/README
+++ b/raspicam_cv/README
@@ -37,9 +37,16 @@ link with the raspicamcv library: -L$(HOME)/git/robidouille/raspicam_cv -lraspic
 link with the userland libraries: -L$(HOME)/git/raspberrypi/userland/build/lib -lmmal_core -lmmal -l mmal_util -lvcos -lbcm_host
 
 In your code add a #include "RaspiCamCV.h", and replace:
--cvCreateCameraCapture -> raspiCamCvCreateCameraCapture
+-cvCreateCameraCapture -> raspiCamCvCreateCameraCapture (function is analog to
+cvCreateCameraCapture and delivers pictures in 640x480 resolution)
 -cvQueryFrame -> raspiCamCvQueryFrame
 -CvCapture -> RaspiCamCvCapture
+
+If you want to capture pictures in a different resolution that 640x480, you can
+also instantiate your own RaspiCamCvCapture by calling
+raspiCamCvCreateCameraCaptureWithDims. This is the function that
+cvCreateCameraCapture delegates to. It allows you to set the dimensions of the
+pictures in pixels directly.
 
 Credits:
 --------------------------------------------------

--- a/raspicam_cv/RaspiCamCV.c
+++ b/raspicam_cv/RaspiCamCV.c
@@ -416,11 +416,17 @@ static void check_disable_port(MMAL_PORT_T *port)
       mmal_port_disable(port);
 }
 
-RaspiCamCvCapture * raspiCamCvCreateCameraCapture(int index)
+void raspiCamCvSetCaptureProperty(RaspiCamCvCapture * capture, int property_id, double value)
 {
-		return raspiCamCvCreateCameraCaptureWithDims(640, 480);
+	if (property_id == RPI_CAP_PROP_FRAME_HEIGHT)
+        capture->pState->height = value;
+	else if (property_id == RPI_CAP_PROP_FRAME_WIDTH)
+		capture->pState->height = value;
+	else if (property_id == RPI_CAP_PROP_FPS)
+		capture->pState->framerate = value;
 }
-RaspiCamCvCapture * raspiCamCvCreateCameraCaptureWithDims(int width, int height)
+
+RaspiCamCvCapture * raspiCamCvCreateCameraCapture(int index)
 {
 	RaspiCamCvCapture * capture = (RaspiCamCvCapture*)malloc(sizeof(RaspiCamCvCapture));
 	// Our main data storage vessel..
@@ -435,8 +441,6 @@ RaspiCamCvCapture * raspiCamCvCreateCameraCaptureWithDims(int width, int height)
 
 	// read default status
 	default_status(state);
-	state->width = width;
-	state->height = height;
 
 	int w = state->width;
 	int h = state->height;
@@ -537,10 +541,6 @@ void raspiCamCvReleaseCapture(RaspiCamCvCapture ** capture)
 	free(state);
 	free(*capture);
 	*capture = 0;
-}
-
-void raspiCamCvSetCaptureProperty(RaspiCamCvCapture * capture, int property_id, double value)
-{
 }
 
 IplImage * raspiCamCvQueryFrame(RaspiCamCvCapture * capture)

--- a/raspicam_cv/RaspiCamCV.c
+++ b/raspicam_cv/RaspiCamCV.c
@@ -418,6 +418,10 @@ static void check_disable_port(MMAL_PORT_T *port)
 
 RaspiCamCvCapture * raspiCamCvCreateCameraCapture(int index)
 {
+		return raspiCamCvCreateCameraCaptureWithDims(640, 480);
+}
+RaspiCamCvCapture * raspiCamCvCreateCameraCaptureWithDims(int width, int height)
+{
 	RaspiCamCvCapture * capture = (RaspiCamCvCapture*)malloc(sizeof(RaspiCamCvCapture));
 	// Our main data storage vessel..
 	RASPIVID_STATE * state = (RASPIVID_STATE*)malloc(sizeof(RASPIVID_STATE));
@@ -431,6 +435,8 @@ RaspiCamCvCapture * raspiCamCvCreateCameraCapture(int index)
 
 	// read default status
 	default_status(state);
+	state->width = width;
+	state->height = height;
 
 	int w = state->width;
 	int h = state->height;

--- a/raspicam_cv/RaspiCamCV.c
+++ b/raspicam_cv/RaspiCamCV.c
@@ -117,8 +117,8 @@ static void default_status(RASPIVID_STATE *state)
 
    // Now set anything non-zero
    state->finished          = 0;
-   state->width 			= 640;      // use a multiple of 320 (640, 1280)
-   state->height 			= 480;		// use a multiple of 240 (480, 960)
+   state->width 			= 2592;      // use a multiple of 320 (640, 1280)
+   state->height 			= 1944;		// use a multiple of 240 (480, 960)
    state->bitrate 			= 17000000; // This is a decent default bitrate for 1080p
    state->framerate 		= VIDEO_FRAME_RATE_NUM;
    state->immutableInput 	= 1;

--- a/raspicam_cv/RaspiCamCV.h
+++ b/raspicam_cv/RaspiCamCV.h
@@ -13,10 +13,26 @@ typedef struct {
 
 typedef struct _IplImage IplImage;
 
+enum
+{
+	RPI_CAP_PROP_FRAME_WIDTH  = 0,
+	RPI_CAP_PROP_FRAME_HEIGHT = 1,
+	RPI_CAP_PROP_FPS          = 2
+};
+
 RaspiCamCvCapture * raspiCamCvCreateCameraCapture(int index);
-RaspiCamCvCapture * raspiCamCvCreateCameraCaptureWithDims(int width, int height);
 void raspiCamCvReleaseCapture(RaspiCamCvCapture ** capture);
-void raspiCamCvSetCaptureProperty(RaspiCamCvCapture * capture, int property_id, double value);
+/**
+ * Set a property in the RaspiCamCvCapture.
+ *
+ * capture - Pointer to the capture to modify
+ * property_id - Property to change. Possible property ids:
+ * 	RPI_CAP_PROP_FRAME_WIDTH - Width of the frames in the stream.
+ * 	RPI_CAP_PROP_FRAME_HEIGHT - Height of the frames in the stream.
+ * value - Value to set the property to
+ */
+int raspiCamCvSetCaptureProperty(RaspiCamCvCapture * capture, int property_id,
+		double value);
 IplImage * raspiCamCvQueryFrame(RaspiCamCvCapture * capture);
 
 #ifdef __cplusplus

--- a/raspicam_cv/RaspiCamCV.h
+++ b/raspicam_cv/RaspiCamCV.h
@@ -14,6 +14,7 @@ typedef struct {
 typedef struct _IplImage IplImage;
 
 RaspiCamCvCapture * raspiCamCvCreateCameraCapture(int index);
+RaspiCamCvCapture * raspiCamCvCreateCameraCaptureWithDims(int width, int height);
 void raspiCamCvReleaseCapture(RaspiCamCvCapture ** capture);
 void raspiCamCvSetCaptureProperty(RaspiCamCvCapture * capture, int property_id, double value);
 IplImage * raspiCamCvQueryFrame(RaspiCamCvCapture * capture);

--- a/raspicam_cv/RaspiCamCV.h
+++ b/raspicam_cv/RaspiCamCV.h
@@ -31,7 +31,7 @@ void raspiCamCvReleaseCapture(RaspiCamCvCapture ** capture);
  * 	RPI_CAP_PROP_FRAME_HEIGHT - Height of the frames in the stream.
  * value - Value to set the property to
  */
-int raspiCamCvSetCaptureProperty(RaspiCamCvCapture * capture, int property_id,
+void raspiCamCvSetCaptureProperty(RaspiCamCvCapture * capture, int property_id,
 		double value);
 IplImage * raspiCamCvQueryFrame(RaspiCamCvCapture * capture);
 


### PR DESCRIPTION
Per your request, camera resolution is now set using raspiCamCvSetCaptureProperty.

_Important:_ I have not been able to test this because of a fried Pi, so please try this out once before you pull. Sorry! As far as I can tell, everything should work great, but my hardware's out of commission at the moment so I can't verify it myself.
