### PR TITLE
Link shared library to opencv

### DIFF
--- a/raspicam_cv/Makefile
+++ b/raspicam_cv/Makefile
@@ -51,7 +51,7 @@ libraspicamcv.a: $(RASPICAMCV_OBJS)
 	ar rcs libraspicamcv.a -o $+
 
 libraspicamcv.so: $(RASPICAMCV_OBJS)
-	gcc -shared -o libraspicamcv.so $+ -Wl,-whole-archive  -lmmal_core -lmmal -l mmal_util -lvcos -lbcm_host -Wl,-no-whole-archive
+	gcc -shared -o libraspicamcv.so $+ -Wl,-whole-archive  -lmmal_core -lmmal -l mmal_util -lvcos -lbcm_host -lopencv_core -lopencv_highgui  -Wl,-no-whole-archive
 
 raspicamtest: $(RASPICAMTEST_OBJS) libraspicamcv.a
 	gcc $(LDFLAGS) $+ $(LDFLAGS2) -L. -lraspicamcv -o $@


### PR DESCRIPTION
Linking libraspicamcv.so against opencv_core and opencv_highgui allows the SO to be loaded in python using ctypes.
Otherwise, the cvResize function will not be recognized. Sample python code:

```
from ctypes import *
cdll.LoadLibrary("./libraspicamcv.so")
libraspicam = CDLL("./libraspicamcv.so")
```
