### PR TITLE
Add library search path which is required for a vanilla raspbian

### DIFF
--- a/raspicam_cv/Makefile
+++ b/raspicam_cv/Makefile
@@ -51,7 +51,7 @@ libraspicamcv.a: $(RASPICAMCV_OBJS)
 	ar rcs libraspicamcv.a -o $+
 
 libraspicamcv.so: $(RASPICAMCV_OBJS)
-	gcc -shared -o libraspicamcv.so $+ -Wl,-whole-archive  -lmmal_core -lmmal -l mmal_util -lvcos -lbcm_host -lopencv_core -lopencv_highgui  -Wl,-no-whole-archive
+	gcc -shared -o libraspicamcv.so $+ -Wl,-whole-archive  -lmmal_core -lmmal -l mmal_util -lvcos -lbcm_host -lopencv_core -lopencv_highgui -L/opt/vc/lib -Wl,-no-whole-archive
 
 raspicamtest: $(RASPICAMTEST_OBJS) libraspicamcv.a
 	gcc $(LDFLAGS) $+ $(LDFLAGS2) -L. -lraspicamcv -o $@


### PR DESCRIPTION
Hi Emil - Rebuilding from a vanilla raspbian wheezy needed this extra library search path:

as per Steff November 13, 2014 at 8:24 am
https://robidouille.wordpress.com/2013/10/19/raspberry-pi-camera-with-opencv/