### PR TITLE
Makefile fixes, config driven capture 

### DIFF
--- a/raspicam_cv/Makefile
+++ b/raspicam_cv/Makefile
@@ -37,7 +37,7 @@ RASPICAMCV_OBJS = \
 RASPICAMTEST_OBJS = \
 	$(OBJS)/RaspiCamTest.o \
 
-TARGETS = libraspicamcv.a libraspicamcv.so raspicamtest
+TARGETS = libraspicamcv.a raspicamtest libraspicamcv.so
 
 all: $(TARGETS)
 

--- a/raspicam_cv/Makefile
+++ b/raspicam_cv/Makefile
@@ -51,7 +51,7 @@ libraspicamcv.a: $(RASPICAMCV_OBJS)
 	ar rcs libraspicamcv.a -o $+
 
 libraspicamcv.so: $(RASPICAMCV_OBJS)
-	gcc -shared -o libraspicamcv.so $+ -Wl,-whole-archive $(LD_FLAGS_PI) -lopencv_core -lopencv_highgui -Wl,-no-whole-archive
+	gcc -shared -o libraspicamcv.so $+ -Wl,-whole-archive $(LDFLAGS_PI) -lopencv_core -lopencv_highgui -Wl,-no-whole-archive
 
 raspicamtest: $(RASPICAMTEST_OBJS) libraspicamcv.a
 	gcc $(LDFLAGS) $+ $(LDFLAGS2) -L. libraspicamcv.a -o $@

--- a/raspicam_cv/Makefile
+++ b/raspicam_cv/Makefile
@@ -54,7 +54,7 @@ libraspicamcv.so: $(RASPICAMCV_OBJS)
 	gcc -shared -o libraspicamcv.so $+ -Wl,-whole-archive $(LD_FLAGS_PI) -lopencv_core -lopencv_highgui -Wl,-no-whole-archive
 
 raspicamtest: $(RASPICAMTEST_OBJS) libraspicamcv.a
-	gcc $(LDFLAGS) $+ $(LDFLAGS2) -L. -lraspicamcv -o $@
+	gcc $(LDFLAGS) $+ $(LDFLAGS2) -L. libraspicamcv.a -o $@
 
 clean:
 	rm -f $(OBJS)/* $(TARGETS)

--- a/raspicam_cv/Makefile
+++ b/raspicam_cv/Makefile
@@ -51,7 +51,7 @@ libraspicamcv.a: $(RASPICAMCV_OBJS)
 	ar rcs libraspicamcv.a -o $+
 
 libraspicamcv.so: $(RASPICAMCV_OBJS)
-	gcc -shared -o libraspicamcv.so $+ -Wl,-whole-archive  -lmmal_core -lmmal -l mmal_util -lvcos -lbcm_host -lopencv_core -lopencv_highgui -L/opt/vc/lib -Wl,-no-whole-archive
+	gcc -shared -o libraspicamcv.so $+ -Wl,-whole-archive $(LD_FLAGS_PI) -lopencv_core -lopencv_highgui -Wl,-no-whole-archive
 
 raspicamtest: $(RASPICAMTEST_OBJS) libraspicamcv.a
 	gcc $(LDFLAGS) $+ $(LDFLAGS2) -L. -lraspicamcv -o $@

--- a/raspicam_cv/README.md
+++ b/raspicam_cv/README.md
@@ -32,7 +32,12 @@ This will create:
 - **libraspicamcv.so**: A shared library of the above
 - **raspicamtest**: A small test app which uses the static library
  
-### Use the static library in your own project ###
+### RaspicamTest ###
+Uses the static library to render a video using OpenCV.
+
+Press Esc to exit.
+
+### Using the static library in your own project ###
 
 Add the include path
 
@@ -50,6 +55,9 @@ In your code add **#include "RaspiCamCV.h"** and replace:
 - cvCreateCameraCapture -> raspiCamCvCreateCameraCapture
 - cvQueryFrame -> raspiCamCvQueryFrame
 - cvReleaseCapture -> raspiCamCvReleaseCapture
+- cvGetCaptureProperty -> raspiCamCvGetCaptureProperty
+
+cvSetCaptureProperty does not currently work. Use the `raspiCamCvCreateCameraCapture2` method to specify width, height, framerate, bitrate and monochrome settings.
  
 ### Credits ###
 RaspiCamCV.c/h is the library source.

--- a/raspicam_cv/README.md
+++ b/raspicam_cv/README.md
@@ -30,14 +30,9 @@ This will create:
 
 - **libraspicamcv.a**: A static raspberry cam library which provides an opencv like interface
 - **libraspicamcv.so**: A shared library of the above
-- **raspicamtest**: A small test app which uses the static library
- 
-### RaspicamTest ###
-Uses the static library to render a video using OpenCV.
+- **raspicamtest**: A small test app which uses the static library. Execute with `./raspicamtest`. Press Esc to exit.
 
-Press Esc to exit.
-
-### Using the static library in your own project ###
+### Using the static library ###
 
 Add the include path
 
@@ -58,11 +53,12 @@ In your code add **#include "RaspiCamCV.h"** and replace:
 - cvGetCaptureProperty -> raspiCamCvGetCaptureProperty
 
 cvSetCaptureProperty does not currently work. Use the `raspiCamCvCreateCameraCapture2` method to specify width, height, framerate, bitrate and monochrome settings.
+
+### Using the shared library ###
+Example C# can be found [here](https://github.com/neutmute/PiCamCV/blob/master/source/LibPiCamCV/PInvoke/CvInvokeRaspiCamCV.cs) which made [this](https://www.youtube.com/watch?v=MWK55A0RH0U).
  
 ### Credits ###
-RaspiCamCV.c/h is the library source.
-
-It's converted from camcv_vid0.c from [Pierre Raufast](https://thinkrpi.wordpress.com/2013/05/22/opencv-and-camera-board-csi/ "Pierre Raufast").
+RaspiCamCV.c/h is converted from camcv_vid0.c from [Pierre Raufast](https://thinkrpi.wordpress.com/2013/05/22/opencv-and-camera-board-csi/ "Pierre Raufast"), which in turn is based on [RaspiVid.c](https://github.com/raspberrypi/userland/blob/master/host_applications/linux/apps/raspicam/RaspiVid.c).
 
 ### More info ###
 - [http://www.robidouille.com](https://robidouille.wordpress.com/2013/10/19/raspberry-pi-camera-with-opencv/)
@@ -70,14 +66,14 @@ It's converted from camcv_vid0.c from [Pierre Raufast](https://thinkrpi.wordpres
 
 
 ### Troubleshooting ###
-#### No rule to make target `objs/RaspiCamControl.o' ####
+#### No rule to make target 'objs/RaspiCamControl.o' ####
 If your userland library is in another directory than as specified above, you need to update the USERLAND_ROOT variable in the Makefile.
 
 #### RaspiCamCV.c:38:16: fatal error: cv.h: No such file or directory  
 You didn't apt-get the suggested libraries at the top of this file
 
 #### (RaspiCamTest:14072): Gtk-WARNING **: cannot open display ####
-You need to run raspicamtest within an X server. Type startx first, open a terminal window, and launch raspicamtest from there.
+You need to run raspicamtest within an X server. Type `startx` first, open a terminal window, and launch raspicamtest from there.
 
 #### raspicamtest causes the entire raspberry pi to crash ####
 Your pi power supply may not be up to the task. Capturing images in a loop makes the pi work hard.

--- a/raspicam_cv/RaspiCamCV.h
+++ b/raspicam_cv/RaspiCamCV.h
@@ -32,7 +32,7 @@ enum
     RPI_CAP_PROP_BITRATE		=37   // no natural mapping here - used CV_CAP_PROP_SETTINGS
 };
 
-//RaspiCamCvCapture * raspiCamCvCreateCameraCapture2(int index, RASPIVID_CONFIG config);
+RaspiCamCvCapture * raspiCamCvCreateCameraCapture2(int index, RASPIVID_CONFIG* config);
 RaspiCamCvCapture * raspiCamCvCreateCameraCapture(int index);
 void raspiCamCvReleaseCapture(RaspiCamCvCapture ** capture);
 double raspiCamCvGetCaptureProperty(RaspiCamCvCapture * capture, int property_id);

--- a/raspicam_cv/RaspiCamCV.h
+++ b/raspicam_cv/RaspiCamCV.h
@@ -7,15 +7,36 @@ extern "C" {
 
 typedef struct _RASPIVID_STATE RASPIVID_STATE;
 
+typedef struct
+{
+	int width;              
+	int height;             
+	int bitrate;            
+	int framerate;          
+	int monochrome;			
+} RASPIVID_CONFIG;
+
 typedef struct {
 	RASPIVID_STATE * pState;
 } RaspiCamCvCapture;
 
 typedef struct _IplImage IplImage;
 
+// Mirror of CV_CAP_PROP_* properties in opencv's highgui_c.h
+enum
+{
+    RPI_CAP_PROP_FRAME_WIDTH    =3,
+    RPI_CAP_PROP_FRAME_HEIGHT   =4,
+    RPI_CAP_PROP_FPS            =5,
+    RPI_CAP_PROP_MONOCHROME		=19,
+    RPI_CAP_PROP_BITRATE		=37   // no natural mapping here - used CV_CAP_PROP_SETTINGS
+};
+
+//RaspiCamCvCapture * raspiCamCvCreateCameraCapture2(int index, RASPIVID_CONFIG config);
 RaspiCamCvCapture * raspiCamCvCreateCameraCapture(int index);
 void raspiCamCvReleaseCapture(RaspiCamCvCapture ** capture);
-void raspiCamCvSetCaptureProperty(RaspiCamCvCapture * capture, int property_id, double value);
+double raspiCamCvGetCaptureProperty(RaspiCamCvCapture * capture, int property_id);
+int raspiCamCvSetCaptureProperty(RaspiCamCvCapture * capture, int property_id, double value);
 IplImage * raspiCamCvQueryFrame(RaspiCamCvCapture * capture);
 
 #ifdef __cplusplus

--- a/raspicam_cv/RaspiCamTest.c
+++ b/raspicam_cv/RaspiCamTest.c
@@ -9,14 +9,48 @@
 
 #include <cv.h>
 #include <highgui.h>
-
+#include <stdio.h>
 #include "RaspiCamCV.h"
 
 int main(int argc, const char** argv){
-    RaspiCamCvCapture * capture = raspiCamCvCreateCameraCapture(0); // Index doesn't really matter
+
+	RASPIVID_CONFIG * config = (RASPIVID_CONFIG*)malloc(sizeof(RASPIVID_CONFIG));
+	
+	config->width=640;
+	config->height=480;
+	config->bitrate=17000000;
+	config->framerate=25;
+	config->monochrome=1;
+
+    RaspiCamCvCapture * capture = (RaspiCamCvCapture *) raspiCamCvCreateCameraCapture2(0, config);
+	
+	//raspiCamCvSetCaptureProperty(capture, RPI_CAP_PROP_FRAME_WIDTH, 640);
+	//raspiCamCvSetCaptureProperty(capture, RPI_CAP_PROP_FRAME_HEIGHT, 480);
+	//raspiCamCvSetCaptureProperty(capture, RPI_CAP_PROP_FPS, 1);	
+	
+	CvFont font;
+	double hScale=0.4;
+	double vScale=0.4;
+	int    lineWidth=1;
+
+	cvInitFont(&font,CV_FONT_HERSHEY_SIMPLEX|CV_FONT_ITALIC, hScale,vScale,0,lineWidth, 8);
+
 	cvNamedWindow("RaspiCamTest", 1);
 	do {
 		IplImage* image = raspiCamCvQueryFrame(capture);
+		
+		char text[200];
+	sprintf(
+			text
+			, "w=%.0f h=%.0f fps=%.0f bitrate=%.0f monochrome=%.0f"
+			, raspiCamCvGetCaptureProperty(capture, RPI_CAP_PROP_FRAME_WIDTH)
+			, raspiCamCvGetCaptureProperty(capture, RPI_CAP_PROP_FRAME_HEIGHT)
+			, raspiCamCvGetCaptureProperty(capture, RPI_CAP_PROP_FPS)
+			, raspiCamCvGetCaptureProperty(capture, RPI_CAP_PROP_BITRATE)
+			, raspiCamCvGetCaptureProperty(capture, RPI_CAP_PROP_MONOCHROME)
+		);
+		cvPutText (image, text, cvPoint(05, 40), &font, cvScalar(255, 255, 0, 0));	
+		
 		cvShowImage("RaspiCamTest", image);
 	} while (cvWaitKey(10) < 0);
 

--- a/raspicam_cv/RaspiCamTest.c
+++ b/raspicam_cv/RaspiCamTest.c
@@ -51,7 +51,10 @@ int main(int argc, const char** argv){
 			, raspiCamCvGetCaptureProperty(capture, RPI_CAP_PROP_BITRATE)
 			, raspiCamCvGetCaptureProperty(capture, RPI_CAP_PROP_MONOCHROME)
 		);
-		cvPutText (image, text, cvPoint(05, 40), &font, cvScalar(255, 255, 0, 0));	
+		cvPutText (image, text, cvPoint(05, 40), &font, cvScalar(255, 255, 0, 0));
+		
+		sprintf(text, "Press ESC to exit");
+		cvPutText (image, text, cvPoint(05, 80), &font, cvScalar(255, 255, 0, 0));
 		
 		cvShowImage("RaspiCamTest", image);
 		

--- a/raspicam_cv/RaspiCamTest.c
+++ b/raspicam_cv/RaspiCamTest.c
@@ -10,21 +10,47 @@
 #include <cv.h>
 #include <highgui.h>
 #include <stdio.h>
+#include <unistd.h>
 #include "RaspiCamCV.h"
 
-int main(int argc, const char** argv){
+int main(int argc, char *argv[ ]){
 
 	RASPIVID_CONFIG * config = (RASPIVID_CONFIG*)malloc(sizeof(RASPIVID_CONFIG));
 	
-	config->width=640;
-	config->height=480;
+	config->width=320;
+	config->height=240;
 	config->bitrate=0;	// zero: leave as default
 	config->framerate=0;
 	config->monochrome=0;
 
+	int opt;
+
+	while ((opt = getopt(argc, argv, "lxm")) != -1)
+	{
+		switch (opt)
+		{
+			case 'l':					// large
+				config->width = 640;
+				config->height = 480;
+				break;
+			case 'x':	   				// extra large
+				config->width = 960;
+				config->height = 720;
+				break;
+			case 'm':					// monochrome
+				config->monochrome = 1;
+				break;
+			default:
+				fprintf(stderr, "Usage: %s [-x] [-l] [-m] \n", argv[0], opt);
+				fprintf(stderr, "-l: Large mode\n");
+				fprintf(stderr, "-x: Extra large mode\n");
+				fprintf(stderr, "-l: Monochrome mode\n");
+				exit(EXIT_FAILURE);
+		}
+	}
+
 	/*
-	Could also use hard coded defaults method
-	raspiCamCvCreateCameraCapture(0)
+	Could also use hard coded defaults method: raspiCamCvCreateCameraCapture(0)
 	*/
     RaspiCamCvCapture * capture = (RaspiCamCvCapture *) raspiCamCvCreateCameraCapture2(0, config); 
 	free(config);

--- a/raspicam_cv/RaspiCamTest.c
+++ b/raspicam_cv/RaspiCamTest.c
@@ -18,29 +18,31 @@ int main(int argc, const char** argv){
 	
 	config->width=640;
 	config->height=480;
-	config->bitrate=17000000;
-	config->framerate=25;
-	config->monochrome=1;
+	config->bitrate=0;	// zero: leave as default
+	config->framerate=0;
+	config->monochrome=0;
 
-    RaspiCamCvCapture * capture = (RaspiCamCvCapture *) raspiCamCvCreateCameraCapture2(0, config);
-	
-	//raspiCamCvSetCaptureProperty(capture, RPI_CAP_PROP_FRAME_WIDTH, 640);
-	//raspiCamCvSetCaptureProperty(capture, RPI_CAP_PROP_FRAME_HEIGHT, 480);
-	//raspiCamCvSetCaptureProperty(capture, RPI_CAP_PROP_FPS, 1);	
+	/*
+	Could also use hard coded defaults method
+	raspiCamCvCreateCameraCapture(0)
+	*/
+    RaspiCamCvCapture * capture = (RaspiCamCvCapture *) raspiCamCvCreateCameraCapture2(0, config); 
+	free(config);
 	
 	CvFont font;
 	double hScale=0.4;
 	double vScale=0.4;
 	int    lineWidth=1;
 
-	cvInitFont(&font,CV_FONT_HERSHEY_SIMPLEX|CV_FONT_ITALIC, hScale,vScale,0,lineWidth, 8);
+	cvInitFont(&font, CV_FONT_HERSHEY_SIMPLEX|CV_FONT_ITALIC, hScale, vScale, 0, lineWidth, 8);
 
 	cvNamedWindow("RaspiCamTest", 1);
+	int exit =0;
 	do {
 		IplImage* image = raspiCamCvQueryFrame(capture);
 		
 		char text[200];
-	sprintf(
+		sprintf(
 			text
 			, "w=%.0f h=%.0f fps=%.0f bitrate=%.0f monochrome=%.0f"
 			, raspiCamCvGetCaptureProperty(capture, RPI_CAP_PROP_FRAME_WIDTH)
@@ -52,7 +54,23 @@ int main(int argc, const char** argv){
 		cvPutText (image, text, cvPoint(05, 40), &font, cvScalar(255, 255, 0, 0));	
 		
 		cvShowImage("RaspiCamTest", image);
-	} while (cvWaitKey(10) < 0);
+		
+		char key = cvWaitKey(10);
+		
+		switch(key)	
+		{
+			case 27:		// Esc to exit
+				exit = 1;
+				break;
+			case 60:		// < (less than)
+				raspiCamCvSetCaptureProperty(capture, RPI_CAP_PROP_FPS, 25);	// Currently NOOP
+				break;
+			case 62:		// > (greater than)
+				raspiCamCvSetCaptureProperty(capture, RPI_CAP_PROP_FPS, 30);	// Currently NOOP
+				break;
+		}
+		
+	} while (!exit);
 
 	cvDestroyWindow("RaspiCamTest");
 	raspiCamCvReleaseCapture(&capture);


### PR DESCRIPTION
Hello Emil,
Some more improvements for your review
* Make file fixes - solves some problems with the shared library conflicting with raspicamtest
* capture params (width, height, monochrome) able to be specified via new method ````raspiCamCvCreateCameraCapture2```` with new struct type
* raspiCamCvGetCaptureProperty works. Aligned the enums RPI_CAP_PROP_* to match OpenCV where possible
* raspiCamCvSetCaptureProperty does not work yet and does a noop. It is a bit tricky for my C skill level at this stage to do properly
* renamed graymode var to monochrome. aligns better with opencv naming.
* raspicamtest demonstrates the new configurable capture capability
* Updates to the readme
````
     ./raspicamtest ### default
     ./raspicamtest -l ### large mode
     ./raspicamtest -x ### extra large mode
     ./raspicamtest -m ### monochrome mode
```
![picam](https://cloud.githubusercontent.com/assets/1303131/6140432/b8f53b24-b1eb-11e4-8777-85bd53071874.png)

cheers!
