### PR TITLE
Update for RGB/BGR firmware correction

### DIFF
--- a/raspicam_cv/RaspiCamCV.c
+++ b/raspicam_cv/RaspiCamCV.c
@@ -251,8 +251,9 @@ static MMAL_COMPONENT_T *create_camera_component(RASPIVID_STATE *state)
 	}
 	else
 	{
-		format->encoding = MMAL_ENCODING_RGB24;
-		format->encoding_variant = MMAL_ENCODING_RGB24;
+		format->encoding =
+			mmal_util_rgb_order_fixed(video_port) ? MMAL_ENCODING_BGR24 : MMAL_ENCODING_RGB24;
+		format->encoding_variant = 0;
 	}
 
 	format->es->video.width = state->width;


### PR DESCRIPTION
The Pi firmware has been corrected so that the camera produces the correct formats when requested for BGR24 or RGB24 as they were swapped. Use the helper function from MMAL to detect this and make the appropriate request on both old and new firmware.

https://www.raspberrypi.org/forums/viewtopic.php?f=43&t=148432
and
https://www.raspberrypi.org/forums/viewtopic.php?f=43&t=154059